### PR TITLE
Update repo links to current repo

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,9 +5,9 @@ site_author: "MagicalCodeMonkey"
 site_url: "https://docs.synclounge.tv/"
 
 # Repository
-repo_name: "samcm/synclounge"
-repo_url: "https://github.com/samcm/synclounge"
-edit_uri: "https://github.com/MagicalCodeMonkey/docs.synclounge.tv/edit/master/docs/"
+repo_name: "synclounge/synclounge"
+repo_url: "https://github.com/synclounge/synclounge"
+edit_uri: "https://github.com/synclounge/docs.synclounge.tv/edit/master/docs/"
 
 # Copyright
 copyright: "Copyright &copy; SyncLounge<br />SyncLounge is not affiliated with Plex Inc."


### PR DESCRIPTION
This updates the links to the old repo names for synclounge and docs.synclounge.tv to the current GitHub user